### PR TITLE
Sanitize breaking spaces rules

### DIFF
--- a/src/xhtml.rs
+++ b/src/xhtml.rs
@@ -141,27 +141,27 @@ impl ToTokens for XhtmlExprE {
               }).to_tokens(tokens);
            }, XhtmlExprE::F(f,p,i,cs) => {
               (quote_spanned!{f.span=>
-                 for #p in #i { #(#cs)* }
+                 for #p in #i { #(#cs)* stream.push_str(" "); }
               }).to_tokens(tokens);
            }, XhtmlExprE::I(i,c,bs,es,e) => {
               (quote_spanned!{i.span=>
-                if #c { #(#bs)* }
+                if #c { #(#bs)* stream.push_str(" "); }
               }).to_tokens(tokens);
 
               for (c,e) in es.iter() {
                  (quote_spanned!{i.span=>
-                    else if #c { #(#e)* }
+                    else if #c { #(#e)* stream.push_str(" "); }
                  }).to_tokens(tokens);
               }
 
               if e.len() > 0 {
                  (quote_spanned!{i.span=>
-                    else { #(#e)* }
+                    else { #(#e)* stream.push_str(" "); }
                  }).to_tokens(tokens);
               }
            }, XhtmlExprE::W(w,i,cs) => {
               (quote_spanned!{w.span=>
-                 while #i { #(#cs)* }
+                 while #i { #(#cs)* stream.push_str(" "); }
               }).to_tokens(tokens);
            }, XhtmlExprE::L(t,l,e) => {
               (quote_spanned!{t.span=>

--- a/src/xhtml.rs
+++ b/src/xhtml.rs
@@ -749,6 +749,9 @@ impl XhtmlCrumb {
     fn parse_outer(input: ParseStream) -> Result<Vec<Self>> {
         let mut cs = vec!();
         while input.peek(Ident) ||
+              input.peek(LitBool) ||
+              input.peek(LitChar) ||
+              input.peek(LitInt) ||
               input.peek(LitStr) ||
               input.peek(Brace) ||
               input.peek(Bracket) ||
@@ -818,6 +821,18 @@ impl Parse for XhtmlCrumb {
         if input.peek(Token![<]) && input.peek2(Token![!]) {
            let c: XhtmlClass = input.parse()?;
            Ok(XhtmlCrumb::C(c))
+        } else if input.peek(LitBool) {
+           let b: LitBool = input.parse()?;
+           Ok(XhtmlCrumb::S(format!("{}",b.value), b.span()))
+        } else if input.peek(LitInt) {
+           let b: LitInt = input.parse()?;
+           Ok(XhtmlCrumb::S(b.base10_digits().to_string(), b.span()))
+        } else if input.peek(LitChar) {
+           let b: LitChar = input.parse()?;
+           Ok(XhtmlCrumb::S(format!("{}",b.value()), b.span()))
+        } else if input.peek(LitStr) {
+           let lit: LitStr = input.parse()?;
+           Ok(XhtmlCrumb::L(lit))
         } else if input.peek(Token![<]) {
            let t: XhtmlTag = input.parse()?;
            Ok(XhtmlCrumb::T(t))
@@ -827,9 +842,6 @@ impl Parse for XhtmlCrumb {
         } else if input.peek(Brace) {
            let e: XhtmlExpr = input.parse()?;
            Ok(XhtmlCrumb::E(e))
-        } else if input.peek(LitStr) {
-           let lit: LitStr = input.parse()?;
-           Ok(XhtmlCrumb::L(lit))
         } else if input.peek(Token![!]) {
            let id: Token![!] = input.parse()?;
            Ok(XhtmlCrumb::S("!".to_string(), id.span.clone()))

--- a/tests/breaking_spaces.rs
+++ b/tests/breaking_spaces.rs
@@ -1,0 +1,20 @@
+#![feature(proc_macro_hygiene)]
+use rdxl::xhtml;
+
+fn bs(s: String) -> String {
+   s.split_whitespace().collect::<Vec<&str>>().join(" ")
+}
+
+#[test]
+fn breaking_for() {
+   assert_eq!(
+      &bs(xhtml!(<ul>
+        <li>1</li>
+        <li>{{ 2 }}</li>
+        {{ for i in 3..5 {{
+          <li>{{ i }}</li>
+        }} }}
+      </ul>)),
+      "<ul> <li>1</li> <li>2</li> <li>3</li> <li>4</li> </ul>"
+   );
+}

--- a/tests/breaking_spaces.rs
+++ b/tests/breaking_spaces.rs
@@ -18,3 +18,40 @@ fn breaking_for() {
       "<ul> <li>1</li> <li>2</li> <li>3</li> <li>4</li> </ul>"
    );
 }
+
+#[test]
+fn breaking_while() {
+   assert_eq!(
+      &bs(xhtml!(<ul>
+        {{ let mut i = 3; }}
+        {{ while i>0 {{
+          <li>{{ i }}</li>
+          {{ i -= 1; }}
+        }} }}
+      </ul>)),
+      "<ul> <li>3</li> <li>2</li> <li>1</li> </ul>"
+   );
+}
+
+#[test]
+fn breaking_if() {
+   assert_eq!(
+      &bs(xhtml!(<ul>
+        {{ let x = 5; }}
+        {{ if x>4 {{
+          <li>1</li>
+        }} }}
+        {{ if x<4 {{
+          <li>1</li>
+        }} else if x>4 {{
+          <li>2</li>
+        }} }}
+        {{ if x<4 {{
+          <li>1</li>
+        }} else {{
+          <li>3</li>
+        }} }}
+      </ul>)),
+      "<ul> <li>1</li> <li>2</li> <li>3</li> </ul>"
+   );
+}

--- a/tests/class_as_attr.rs
+++ b/tests/class_as_attr.rs
@@ -1,6 +1,10 @@
 #![feature(proc_macro_hygiene)]
 use rdxl::{xhtml,xtype,xrender};
 
+fn bs(s: String) -> String {
+   s.split_whitespace().collect::<Vec<&str>>().join(" ")
+}
+
 xtype!(<!MyAttr field:u64><!MyAttrChild field:u64/></MyAttr>);
 xtype!(<!MyType attr:MyAttr/>);
 xrender!(MyType, <ul>
@@ -11,10 +15,10 @@ xrender!(MyType, <ul>
 
 #[test]
 fn complex_classes_as_attr(){
-   assert_eq!(xhtml!(<!MyType attr=<!MyAttr field=3>
+   assert_eq!(bs(xhtml!(<!MyType attr=<!MyAttr field=3>
        <!MyAttrChild field=2/>
        <!MyAttrChild field=1/>
-     </MyAttr>/>),
-     "<ul> <li>3:2</li><li>3:1</li> </ul>".to_string()
+     </MyAttr>/>)),
+     "<ul> <li>3:2</li> <li>3:1</li> </ul>".to_string()
    );
 }

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -1,6 +1,10 @@
 #![feature(proc_macro_hygiene)]
 use rdxl::{xhtml,xtype,xrender};
 
+fn bs(s: String) -> String {
+   s.split_whitespace().collect::<Vec<&str>>().join(" ")
+}
+
 xtype!(<!MyPredefinedType/>);
 xtype!(<!MyList my_string:String my_int:u64>
    <!MyItem my_bool:bool/>
@@ -23,34 +27,30 @@ xrender!(MyList, <ul>
 xrender!(MyItem, <span>my_bool: {{ self.my_bool }}</span>);
 xrender!(MyOtherItem, <span>my_char: {{ self.my_char }}</span>);
 
-fn bs(s: String) -> String {
-   s.split_whitespace().collect::<Vec<&str>>().join(" ")
-}
-
 #[test]
 fn simple_class1() {
    assert_eq!(
-      &bs(xhtml!(<!MyItem my_bool=true/>)),
-      "<span>my_bool: true</span>"
+      bs(xhtml!(<!MyItem my_bool=true/>)),
+      "<span>my_bool: true</span>".to_string()
    );
 }
 
 #[test]
 fn simple_class2() {
    assert_eq!(
-      &bs(xhtml!(<!MyOtherItem my_char='c'></MyOtherItem>)),
-      "<span>my_char: c</span>"
+      bs(xhtml!(<!MyOtherItem my_char='c'></MyOtherItem>)),
+      "<span>my_char: c</span>".to_string()
    );
 }
 
 #[test]
 fn complex_class1(){
    assert_eq!(
-     &bs(xhtml!(<!MyList my_string="abcdefg" my_int=33>
+     bs(xhtml!(<!MyList my_string="abcdefg" my_int=33>
        <!MyItem my_bool=true/>
        <!MyItem my_bool=false/>
        <!MyOtherItem my_char='a'/>
      </MyList>)),
-     "<ul> <li>abcdefg</li> <li>33</li> <li>MyItem: true</li> <li>MyItem: false</li> <li>MyOtherItem: a</li> </ul>"
+     "<ul> <li>abcdefg</li> <li>33</li> <li>MyItem: true</li> <li>MyItem: false</li> <li>MyOtherItem: a</li> </ul>".to_string()
    );
 }

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -51,6 +51,6 @@ fn complex_class1(){
        <!MyItem my_bool=false/>
        <!MyOtherItem my_char='a'/>
      </MyList>)),
-     "<ul> <li>abcdefg</li> <li>33</li> <li>MyItem: true</li><li>MyItem: false</li><li>MyOtherItem: a</li> </ul>"
+     "<ul> <li>abcdefg</li> <li>33</li> <li>MyItem: true</li> <li>MyItem: false</li> <li>MyOtherItem: a</li> </ul>"
    );
 }

--- a/tests/cond.rs
+++ b/tests/cond.rs
@@ -1,12 +1,16 @@
 #![feature(proc_macro_hygiene)]
 use rdxl::xhtml;
 
+fn bs(s: String) -> String {
+   s.split_whitespace().collect::<Vec<&str>>().join(" ")
+}
+
 #[test]
 fn conditional1(){
    let x = 5;
    let y = Some(2);
 
-   assert_eq!(xhtml!(<div>
+   assert_eq!(bs(xhtml!(<div>
       {{ if x > 2 {{
          {{ x }}
       }} }}
@@ -27,6 +31,6 @@ fn conditional1(){
       }} else if let Some(yy) = y {{
          {{ yy }}
       }} }}
-   </div>), 
+   </div>)), 
    "<div> 5 2 7 2 </div>".to_string());
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,6 +1,10 @@
 #![feature(proc_macro_hygiene)]
 use rdxl::{xhtml,xtype,xrender};
 
+fn bs(s: String) -> String {
+   s.split_whitespace().collect::<Vec<&str>>().join(" ")
+}
+
 xtype!(<!MyDisplayList><?/></MyDisplayList>);
 xrender!(MyDisplayList, <ul>
   {{ for d in self.children.iter() {{
@@ -12,20 +16,20 @@ xrender!(MyDisplayList, <ul>
 #[test]
 fn display1() {
    assert_eq!(
-     xhtml!(<!MyDisplayList>
+     bs(xhtml!(<!MyDisplayList>
        <?>{{ format!("a:{}",2) }}</?>
        <?>{{ format!("b:{}",4) }}</?>
-     </MyDisplayList>),
-     "<ul> <li>a:2</li><li>b:4</li> </ul>"
+     </MyDisplayList>)),
+     "<ul> <li>a:2</li> <li>b:4</li> </ul>"
    );
 }
 
 #[test]
 fn display2() {
    assert_eq!(
-     xhtml!(<!MyDisplayList>
+     bs(xhtml!(<!MyDisplayList>
        <?><h2>nested</h2></?>
-     </MyDisplayList>),
+     </MyDisplayList>)),
      "<ul> <li><h2>nested</h2></li> </ul>"
    );
 }

--- a/tests/loops.rs
+++ b/tests/loops.rs
@@ -1,41 +1,45 @@
 #![feature(proc_macro_hygiene)]
 use rdxl::xhtml;
 
+fn bs(s: String) -> String {
+   s.split_whitespace().collect::<Vec<&str>>().join(" ")
+}
+
 #[test]
 fn loops1(){
    let my_int = 3;
    let my_str = "asdf";
    let my_vec = vec![true, false, true, true];
 
-   assert_eq!(xhtml!(<div>
+   assert_eq!(bs(xhtml!(<div>
       {{ for v in my_vec.iter() {{
          <span>{{my_int}}, {{my_str}}, {{v}}</span>
       }} }}
-   </div>),
-   "<div> <span>3, asdf, true</span><span>3, asdf, false</span><span>3, asdf, true</span><span>3, asdf, true</span> </div>".to_string());
+   </div>)),
+   "<div> <span>3, asdf, true</span> <span>3, asdf, false</span> <span>3, asdf, true</span> <span>3, asdf, true</span> </div>".to_string());
 }
 
 #[test]
 fn loops2(){
    let mut my_counter = 3;
 
-   assert_eq!(xhtml!(<div>
+   assert_eq!(bs(xhtml!(<div>
       {{ while my_counter > 0 {{
          <span>{{my_counter}}</span>
          {{ my_counter -= 1; }}
       }} }}
-   </div>),
-   "<div> <span>3</span><span>2</span><span>1</span> </div>".to_string());
+   </div>)),
+   "<div> <span>3</span> <span>2</span> <span>1</span> </div>".to_string());
 }
 
 #[test]
 fn loops3(){
    let mut my_some = Some(23);
-   assert_eq!(xhtml!(<div>
+   assert_eq!(bs(xhtml!(<div>
       {{ while let Some(my_num) = my_some {{
          <span>{{my_num}}</span>
          {{ my_some = None; }}
       }} }}
-   </div>),
+   </div>)),
    "<div> <span>23</span> </div>".to_string());
 }


### PR DESCRIPTION
**while** **if** and **for** all emit breaking spaces regardless of span values. This is probably the safest route to avoid breakage across Rust versions.